### PR TITLE
Feature: #30 Add Pie Chart Support For Negative Values

### DIFF
--- a/app/views/_pie.html.erb
+++ b/app/views/_pie.html.erb
@@ -11,9 +11,10 @@
                     <%=object[:percent_value] > 0.5 ? 1 : 0%> 1
                     <%= 150 - 125 * Math.cos(2 * Math::PI * cumulative_percent)%> 
                     <%= 150 - 125 * Math.sin(2 * Math::PI * cumulative_percent)%> Z" 
-                stroke="White" 
-                fill="<%=object[:color]%>"
-                stroke-width="1" />
+                stroke="<%= object[:is_negative] == 1 ? object[:color] : 'white' %>"
+                stroke-dasharray= '<%= object[:is_negative] == 1 ? 30 : 0 %>'
+                fill="<%= object[:is_negative] == 1 ? 'white' : object[:color] %>"
+                stroke-width="<%= object[:is_negative] == 1 ? 5 : 1 %>" />
                 <%-arc_x = 150 - 125 * Math.cos(2 * Math::PI * cumulative_percent)%>
                 <%-arc_y = 150 - 125 * Math.sin(2 * Math::PI * cumulative_percent)%>
 
@@ -28,6 +29,7 @@
         </svg>
     </div>
     <%# Insert the key here %>
+
 </div>
 
 <%= render :partial => '/styles' %>

--- a/lib/purechart/chart_helper.rb
+++ b/lib/purechart/chart_helper.rb
@@ -126,20 +126,36 @@ module PureChart
         end
 
         def pie_chart(data)
+            # check for negative values 
+            has_negative_value = 0
+
             # Find total value for calculating percentages 
             total_value = 0
             data.each do |object|
-                total_value += object[:value]
+                total_value += (object[:value]).abs 
             end
             # Calculate percentages for each data point
             data.each do |object|
-                object[:percent_value] = Float(object[:value]) / total_value
+                object[:percent_value] = (Float(object[:value]) / total_value).abs 
+                if object[:value] < 0 
+                    object[:is_negative] = 1
+                    has_negative_value = 1 
+                else
+                    object[:is_negative] = 0
+                end
             end
 
+            negative_value = {
+                negative: has_negative_value
+            }
+        
             ActionController::Base.render partial: '/pie', locals: {
-                data: data
+                data: data,
+                negative_value: negative_value
             }
         end
+    
+
 
         def box_plot(data, configuration = {}, path="")
 


### PR DESCRIPTION
**Description:** 

Pie chart now supports inputs of negative data value with the new graphical representation on the pie chart. Now, it becomes clear why we have a blank slice in the pie. Additionally, with the dotted online still giving the user a appealing look on the chart. 


<img width="260" alt="Screenshot 2024-03-17 at 10 49 20 PM" src="https://github.com/PureChart/purechart/assets/146267367/8be9f01c-5460-4ed4-bf0b-f1b0f0b03731">


**Change include:**

 - Adding the ().abs for user to input negative data values 
 - Allow the blog to show the blank slice for negative data values 
 


**Issue still present:**
- Wasn't able to get the error message to pop up, as I have tried the example one you have given me but it would just bring me to the error message showing up. If that's the case then the pie chart won't support negative data values. But will be down to try to resolve that in a later PR.  