### PR TITLE
Add Pie Chart Key

### DIFF
--- a/app/views/_pie.html.erb
+++ b/app/views/_pie.html.erb
@@ -1,5 +1,5 @@
 <div class="chart-flex-container" style="width: fit-content">
-    <div class="pie">
+    <div class="pie-flex-container" display="flex" flex-direction="row" flex-wrap="wrap" justify-content="center" align-items="center">
         <svg height="250" width="250" viewBox="0 0 300 300">
             <%-arc_x = 25%>
             <%-arc_y = 150%>
@@ -17,17 +17,22 @@
                 <%-arc_x = 150 - 125 * Math.cos(2 * Math::PI * cumulative_percent)%>
                 <%-arc_y = 150 - 125 * Math.sin(2 * Math::PI * cumulative_percent)%>
 
-                <circle class="pie-slice-arc" r='135' cx='150' cy='150' fill='none'
+                <circle class="pie-slice-arc <%=index%>" r='135' cx='150' cy='150' fill='none'
                     stroke="<%=object[:color]%>"
                     stroke-width='16'
                     stroke-dasharray='calc(<%=object[:percent_value]%> * 2 * pi * 135) calc(2 * pi * 135)' 
                     stroke-opacity='0'
                     transform='rotate(<%=cumulative_angle%>, 150, 150)'/>
                 <%-cumulative_angle += 360 * object[:percent_value]%>
-            <% end %>
+            <%end%>
+        </svg>
+        <svg class="pie-key" height="250" width="125" viewBox="0 0 125 250">
+            <%-data.each_with_index do |object, index|%>
+                <circle class="pie-slice-arc <%=index%>" r="5" cx="10" cy='<%=(250/num_data[:total_num])/2 + 250/num_data[:total_num] * index%>' fill="<%=object[:color]%>"/>
+                <text x="20" dy='<%=(250/num_data[:total_num])/2 + 250/num_data[:total_num] * index%>' alignment-baseline="middle"><%=object[:name]%></text>
+            <%end%>
         </svg>
     </div>
-    <%# Insert the key here %>
 </div>
 
 <%= render :partial => '/styles' %>

--- a/app/views/_pie.html.erb
+++ b/app/views/_pie.html.erb
@@ -1,6 +1,6 @@
 <div class="chart-flex-container" style="width: fit-content">
-    <div class="pie-flex-container" display="flex" flex-direction="row" flex-wrap="wrap" justify-content="center" align-items="center">
-        <svg height="250" width="250" viewBox="0 0 300 300">
+    <div class="pie-flex-container">
+        <svg class="pie-chart" height="250" width="250" viewBox="0 0 300 300">
             <%-arc_x = 25%>
             <%-arc_y = 150%>
             <%-cumulative_percent = 0%>
@@ -26,12 +26,14 @@
                 <%-cumulative_angle += 360 * object[:percent_value]%>
             <%end%>
         </svg>
-        <svg class="pie-key" height="250" width="125" viewBox="0 0 125 250">
+        <div class="pie-key-flex-container">
             <%-data.each_with_index do |object, index|%>
-                <circle class="pie-slice-arc <%=index%>" r="5" cx="10" cy='<%=(250/num_data[:total_num])/2 + 250/num_data[:total_num] * index%>' fill="<%=object[:color]%>"/>
-                <text x="20" dy='<%=(250/num_data[:total_num])/2 + 250/num_data[:total_num] * index%>' alignment-baseline="middle"><%=object[:name]%></text>
+                <svg class="pie-key" width="50%" viewBox="0 0 auto auto">
+                    <circle class="pie-key-circle <%=index%>" r="5" cx="10%" cy='50%' fill="<%=object[:color]%>"/>
+                    <text x="15%" dy='50%' alignment-baseline="middle"><%=object[:name]%></text>
+                </svg>
             <%end%>
-        </svg>
+        </div>
     </div>
 </div>
 

--- a/app/views/_pie.html.erb
+++ b/app/views/_pie.html.erb
@@ -1,40 +1,85 @@
-<div class="chart-flex-container" style="width: fit-content">
-    <div class="pie-flex-container">
-        <svg class="pie-chart" height="250" width="250" viewBox="0 0 300 300">
-            <%-arc_x = 25%>
-            <%-arc_y = 150%>
-            <%-cumulative_percent = 0%>
-            <%-cumulative_angle = -180%>
-            <%-data.each_with_index do |object, index|%>
-                <%-cumulative_percent += object[:percent_value]%>
-                <path class="pie-slice" d="M 150 150 L <%=arc_x%> <%=arc_y%> A 125 125 0 
-                    <%=object[:percent_value] > 0.5 ? 1 : 0%> 1
-                    <%= 150 - 125 * Math.cos(2 * Math::PI * cumulative_percent)%> 
-                    <%= 150 - 125 * Math.sin(2 * Math::PI * cumulative_percent)%> Z" 
+<div class="chart-flex-container">
+    <div class="pie-flex-container" style="width: fit-content; max-width: 100%; margin: 0 auto; display: flex; display-direction: row">
+        <svg class="pie-chart" style="width: 300px; max-width: 100%;" viewBox="0 0 300 300">
+            <%- arc_x = 25 %>
+            <%- arc_y = 150 %>
+            <%- cumulative_percent = 0 %>
+            <%- cumulative_angle = -180 %>
+            <%# Calculate arc coordinates to draw each slice %>
+            <%- data.each_with_index do |object, index| %>
+                <%- cumulative_percent += object[:percent_value] %>
+                <path class="pie-slice" id="pie-slice-<%= index %>" d="M 150 150 L <%= arc_x %> <%= arc_y %> A 125 125 0 
+                    <%= object[:percent_value] > 0.5 ? 1 : 0 %> 1
+                    <%= 150 - 125 * Math.cos(2 * Math::PI * cumulative_percent) %> 
+                    <%= 150 - 125 * Math.sin(2 * Math::PI * cumulative_percent) %> Z" 
                 stroke="White" 
-                fill="<%=object[:color]%>"
-                stroke-width="1" />
-                <%-arc_x = 150 - 125 * Math.cos(2 * Math::PI * cumulative_percent)%>
-                <%-arc_y = 150 - 125 * Math.sin(2 * Math::PI * cumulative_percent)%>
+                fill="<%= object[:color] %>"
+                stroke-width="1" --name="<%= object[:name] %>"/>
+                <%- arc_x = 150 - 125 * Math.cos(2 * Math::PI * cumulative_percent) %>
+                <%- arc_y = 150 - 125 * Math.sin(2 * Math::PI * cumulative_percent) %>
 
-                <circle class="pie-slice-arc <%=index%>" r='135' cx='150' cy='150' fill='none'
-                    stroke="<%=object[:color]%>"
+                <%# Render arc highlights for hover effect %>
+                <circle class="pie-slice-arc" id="pie-slice-arc-<%= index %>" r='135' cx='150' cy='150' fill='none'
+                    stroke="<%= object[:color] %>"
                     stroke-width='16'
-                    stroke-dasharray='calc(<%=object[:percent_value]%> * 2 * pi * 135) calc(2 * pi * 135)' 
+                    stroke-dasharray='calc(<%= object[:percent_value] %> * 2 * pi * 135) calc(2 * pi * 135)' 
                     stroke-opacity='0'
-                    transform='rotate(<%=cumulative_angle%>, 150, 150)'/>
-                <%-cumulative_angle += 360 * object[:percent_value]%>
-            <%end%>
+                    transform='rotate(<%= cumulative_angle %>, 150, 150)'/>
+                <%- cumulative_angle += 360 * object[:percent_value] %>
+            <% end %>
         </svg>
+        <%# Pie chart key %>
         <div class="pie-key-flex-container">
-            <%-data.each_with_index do |object, index|%>
-                <svg class="pie-key" width="50%" viewBox="0 0 auto auto">
-                    <circle class="pie-key-circle <%=index%>" r="5" cx="10%" cy='50%' fill="<%=object[:color]%>"/>
-                    <text x="15%" dy='50%' alignment-baseline="middle"><%=object[:name]%></text>
+            <%- data.each_with_index do |object, index| %>
+                <svg class="pie-key" id="pie-key-<%= index %>" width="50%" viewBox="0 0 auto auto">
+                    <circle class="pie-key-circle" id="pie-key-circle-<%= index %>" r="5" cx="5%" cy='50%' fill="<%= object[:color] %>"/>
+                    <text class="pie-key-text" id="pie-key-text-<%= index %>" x="15%" dy='50%' alignment-baseline="middle"><%= object[:name] %></text>
                 </svg>
-            <%end%>
+            <% end %>
         </div>
     </div>
 </div>
+
+<style>
+<%# Styling for hover effects between chart and key %>
+<%- data.each_with_index do |object, index| %>
+.pie-flex-container:has(#pie-slice-<%= index %>:hover) #pie-key-circle-<%= index %> {
+    stroke: <%= object[:color] %>;
+    r: 5%;
+	fill-opacity: 0.5;
+	transition: 0.05s all ease;
+}
+.pie-flex-container:has(#pie-slice-<%= index %>:hover) #pie-key-text-<%= index %> {
+    fill: <%= object[:color] %>;
+	transform: translateX(2.5%);
+	transition: 0.2s all ease;
+}
+.pie-flex-container:has(#pie-key-<%= index %>:hover) #pie-slice-<%= index %> {
+    fill-opacity: 0.8;
+	transform: translateX(0.1%);
+	transition: 0.25s all ease;
+}
+.pie-flex-container:has(#pie-key-<%= index %>:hover) #pie-slice-arc-<%= index %> {
+    fill-opacity: 0.8;
+	stroke-opacity: 0.3;
+	transition: 0.05s all ease;
+}
+
+#pie-key-<%= index %>:hover #pie-key-circle-<%= index %> {
+	stroke: <%= object[:color] %>;
+    r: 5%;
+	fill-opacity: 0.5;
+	transition: 0.05s all ease;
+}
+
+#pie-key-<%= index %>:hover #pie-key-text-<%= index %> {
+    fill: <%= object[:color] %>;
+	transform: translateX(2.5%);
+	transition: 0.2s all ease;
+}
+
+<% end %>
+
+</style>
 
 <%= render :partial => '/styles' %>

--- a/app/views/_styles.html.erb
+++ b/app/views/_styles.html.erb
@@ -51,7 +51,8 @@ h4.purechart {
 	transition: 0.25s all ease;
 }
 
-.pie-slice:hover:nth-child(1n + 0) + .pie-slice-arc:nth-child(1n+0) {
+.pie-slice:hover:nth-child(1n + 0) + .pie-slice-arc:nth-child(1n+0){
+	fill-opacity: 0.8;
 	stroke-opacity: 0.3;
 	transition: 0.05s all ease;
 }

--- a/app/views/_styles.html.erb
+++ b/app/views/_styles.html.erb
@@ -46,6 +46,24 @@ h4.purechart {
 	color: transparent
 }
 
+.pie-flex-container {
+	display: flex;
+}
+.pie-chart {
+	flex: 1 1 auto;
+}
+
+.pie-key-flex-container {
+	display: flex;
+	flex-direction: column;
+	flex-flow: column wrap;	
+	max-height: 250px;
+}
+.pie-key {
+	flex: 1 1 auto;
+	min-height: 15px;
+}
+
 .pie-slice:hover {
 	fill-opacity: 0.8;
 	transition: 0.25s all ease;

--- a/app/views/_styles.html.erb
+++ b/app/views/_styles.html.erb
@@ -42,15 +42,27 @@ h4.purechart {
 	z-index: 1;
 }
 
-.pie {
-	color: transparent
-}
-
 .pie-flex-container {
 	display: flex;
 }
 .pie-chart {
 	flex: 1 1 auto;
+}
+
+.pie-slice:hover {
+	fill-opacity: 0.8;
+	transform: translateX(0.1%);
+	transition: 0.25s all ease;
+}
+
+.pie-slice-arc {
+	pointer-events: none;
+}
+
+.pie-slice:hover:nth-child(1n+0) + .pie-slice-arc:nth-child(1n+0){
+	fill-opacity: 0.8;
+	stroke-opacity: 0.3;
+	transition: 0.05s all ease;
 }
 
 .pie-key-flex-container {
@@ -62,17 +74,6 @@ h4.purechart {
 .pie-key {
 	flex: 1 1 auto;
 	min-height: 15px;
-}
-
-.pie-slice:hover {
-	fill-opacity: 0.8;
-	transition: 0.25s all ease;
-}
-
-.pie-slice:hover:nth-child(1n + 0) + .pie-slice-arc:nth-child(1n+0){
-	fill-opacity: 0.8;
-	stroke-opacity: 0.3;
-	transition: 0.05s all ease;
 }
 
 .bar-chart-bar {

--- a/lib/purechart/chart_helper.rb
+++ b/lib/purechart/chart_helper.rb
@@ -128,16 +128,24 @@ module PureChart
         def pie_chart(data)
             # Find total value for calculating percentages 
             total_value = 0
+            total_num = 0
             data.each do |object|
                 total_value += object[:value]
+                total_num += 1
             end
+
             # Calculate percentages for each data point
             data.each do |object|
                 object[:percent_value] = Float(object[:value]) / total_value
             end
 
+            num_data = {
+                total_num: total_num
+            }
+
             ActionController::Base.render partial: '/pie', locals: {
-                data: data
+                data: data,
+                num_data: num_data
             }
         end
 

--- a/lib/purechart/chart_helper.rb
+++ b/lib/purechart/chart_helper.rb
@@ -139,13 +139,13 @@ module PureChart
                 object[:percent_value] = Float(object[:value]) / total_value
             end
 
-            num_data = {
+            additional_data = {
                 total_num: total_num
             }
 
             ActionController::Base.render partial: '/pie', locals: {
                 data: data,
-                num_data: num_data
+                additional_data: additional_data
             }
         end
 

--- a/lib/purechart/chart_helper.rb
+++ b/lib/purechart/chart_helper.rb
@@ -128,10 +128,8 @@ module PureChart
         def pie_chart(data)
             # Find total value for calculating percentages 
             total_value = 0
-            total_num = 0
             data.each do |object|
                 total_value += object[:value]
-                total_num += 1
             end
 
             # Calculate percentages for each data point
@@ -139,13 +137,8 @@ module PureChart
                 object[:percent_value] = Float(object[:value]) / total_value
             end
 
-            additional_data = {
-                total_num: total_num
-            }
-
             ActionController::Base.render partial: '/pie', locals: {
                 data: data,
-                additional_data: additional_data
             }
         end
 


### PR DESCRIPTION
## Description
Added interactive key beside pie chart. Cross-over exists so hovering over an element highlights the name and corresponding slice on pie chart. Hovering over a slice highlights the corresponding name on the key.

The key can fit up to 16 elements per column and an indefinite number of rows (it overflows if there's too many though - may need new issue to deal with extremely large numbers of elements).

Added rudimentary scaling with website resizing but this will definitely need to be tweaked and updated, especially if the key will dynamically resize.

<img width="428" alt="image" src="https://github.com/PureChart/purechart/assets/146519652/8da777d3-abaf-4de0-917f-4a6cb02c15a2">

### Changes include:
- Adding new flex container beside pie chart for key
- CSS hover effects
- SVG Key elements
- Rudimentary scaling with website

### Issues Still Present:
- If the key expands off the screen, then scaling becomes weird
- The key is not perfectly centered vertically

**Notes:**
- Highlights and style can all be changed if needed
- Also, if there's any merging conflicts/issues with Negative Value Support, I can take a look at it