### PR TITLE
Added Corner Radius Config Option for Bar Chart

### DIFF
--- a/app/views/_bar.html.erb
+++ b/app/views/_bar.html.erb
@@ -2,7 +2,7 @@
 	<div class="chart" style="border-left: <%=  style['axes']['style'] %>; border-bottom: <%=  style['axes']['style'] %>">
 		<div class="chart-elements">
 			<%- data.each do |object| %>
-			<div class="bar bar-chart-bar" style="width: <%= object[:width] %>%; background-color: <%= style['colors'][object[:color]] || object[:color] %>;">
+			<div class="bar bar-chart-bar" style="width: <%= object[:width] %>%; background-color: <%= style['colors'][object[:color]] || object[:color] %>; border-top-right-radius: <%= configuration[:corner_radius] %>; border-bottom-right-radius: <%= configuration[:corner_radius] %>;">
 				<p class="bar-title bar-chart-bar-title" style="font-family: <%= style['labels']['font'] %>; font-weight: <%= style['labels']['weight'] %>; color: <%= style['labels']['color'] %>"><%= object[:name] %></p>
 					<div class="tooltip">
 						<p style="color: <%= style['colors'][object[:color]] || object[:color] %>;"><%= object[:name] %></p>

--- a/app/views/_styles.html.erb
+++ b/app/views/_styles.html.erb
@@ -115,6 +115,8 @@ h4.purechart {
 
 	margin-bottom: 32px;
 	position: relative;
+	border-top-right-radius: 5px;
+	border-bottom-right-radius: 5px;
 
 	cursor: pointer;
 	z-index: 1;

--- a/lib/purechart/chart_helper.rb
+++ b/lib/purechart/chart_helper.rb
@@ -57,7 +57,7 @@ module PureChart
             }
         end
 
-        def bar_chart(data, configuration = { axes: { horizontal: "Value" } }, path="")
+        def bar_chart(data, configuration = { axes: { horizontal: "Value" }, corner_radius: "Value" }, path="")
             # Set default configuration file path
             default_config_path = File.join( File.dirname(__FILE__), 'styles/default.yml' )
 


### PR DESCRIPTION
## Changes
* Modified bar_chart helper in lib/purechart/chart_helper.rb to include an option for setting the corner radius
* Edited app/views/_bar.html.erb to set the corner radius to a user-defined value 
* Edited app/views/_styles.html.erb to include a default value for the corner radius 

#### Some Corner Radius
<img src="https://github.com/PureChart/purechart/assets/149223712/ee895a78-ec68-4d29-8415-6a4710183dfe" alt="Description" width="450" height="390">

#### Full Corner Radius
<img src="https://github.com/PureChart/purechart/assets/149223712/933fb10e-515c-4b45-8f6d-150d3616ad23" alt="Description" width="450" height="390">

